### PR TITLE
Enforce https requests

### DIFF
--- a/wikipedia/article.rb
+++ b/wikipedia/article.rb
@@ -2,7 +2,7 @@ require 'rest-client'
 module Article
   def find_article lat, long
     endpoint_geo = "https://en.wikipedia.org/w/api.php?action=query&format=json&list=geosearch&gsradius=10000&gscoord="
-    endpoint_article = "http://en.wikipedia.org/w/api.php?action=query&prop=extracts&format=json&titles="
+    endpoint_article = "https://en.wikipedia.org/w/api.php?action=query&prop=extracts&format=json&titles="
     response = JSON.parse RestClient::Request.execute(:url => URI.encode(endpoint_geo + "#{lat}|#{long}"), :method => :get, :verify_ssl => false)
     size = response['query']['geosearch'].size
     title = response['query']['geosearch'][rand size]['title']


### PR DESCRIPTION
The first url is https, so why not the second as well?
